### PR TITLE
Fix null reference exception and support error in msbuild.xml

### DIFF
--- a/BuildAnalyzer/LogAnalyzer.cs
+++ b/BuildAnalyzer/LogAnalyzer.cs
@@ -30,8 +30,21 @@ namespace BuildAnalyzer
                         if (logLine.Contains(": error"))
                         {
                             var errorDetails = errorParser.ParseError(logLine);
-                            WriteCodeLine(errorDetails);
-                            _projects.Add(errorDetails.Project);
+
+                            if (string.IsNullOrEmpty(errorDetails.File))
+                            {
+                                _resultWriter.WriteLine(errorDetails.Description);
+                            }
+                            else
+                            {
+                                WriteDetailedError(errorDetails);
+                            }
+
+                            if (!string.IsNullOrEmpty(errorDetails.Project))
+                            {
+                                _projects.Add(errorDetails.Project);
+                            }
+
                             errorCount++;
                         }
 
@@ -50,7 +63,7 @@ namespace BuildAnalyzer
         }
 
 
-        void WriteCodeLine(ErrorDetails errorDetails)
+        void WriteDetailedError(ErrorDetails errorDetails)
         {
             try
             {
@@ -74,12 +87,10 @@ namespace BuildAnalyzer
                         if (line == errorDetails.Line)
                         {
                             _resultWriter.WriteLine(line + ": " + codeLine.Replace("\t", " "));
-                            var errorDescription =
-                                errorDetails.Description.Substring(errorDetails.Description.IndexOf(':') + 2);
-                            _resultWriter.WriteLine(
-                                new string('-', errorDetails.Column - 1 + line.ToString().Length + 2) + '^' + "  " +
-                                errorDescription);
+                            _resultWriter.WriteLine(new string('-', errorDetails.Column + line.ToString().Length + 1) +
+                                                    '^' + "  " + errorDetails.Description);
                             _resultWriter.WriteLine(errorDetails.File + " " + lastProgram);
+                            break;
                         }
                     }
                     _resultWriter.WriteLine();
@@ -96,11 +107,15 @@ namespace BuildAnalyzer
             _resultWriter.WriteLine("Total errors: " + counter);
             _resultWriter.WriteLine("========================");
             _resultWriter.WriteLine("");
-            _resultWriter.WriteLine("Projects:");
 
-            foreach (var project in _projects)
+            if (_projects.Count > 0)
             {
-                _resultWriter.WriteLine(project);
+                _resultWriter.WriteLine("Projects:");
+
+                foreach (var project in _projects)
+                {
+                    _resultWriter.WriteLine(project);
+                }
             }
         }
     }

--- a/UnitTests/MockLogWithErrorInMsbuildXml.cs
+++ b/UnitTests/MockLogWithErrorInMsbuildXml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests
+{
+    class MockLogWithErrorInMsbuildXml : MockFilesProvider
+    {
+        protected override string GetLogText()
+        {
+            return "     1>d:\\Etobres\\CustomerMigration\\Dotnet\\msbuild.xml(3,19): error MSB4025: The project file could not be loaded. '<', hexadecimal value 0x3C, is an invalid attribute character. Line 3, position 19.\r\n";
+        }
+
+        protected override string GetCodeFileText(string fileName)
+        {
+            return "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n" +
+                   "<Project DefaultTargets=\"Step0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\" ToolsVersion=\"3.5\">\r\n" +
+                   "    <Target Name=\"<!$SB_TARGET>\" DependsOnTargets=\"<!$SB_DEPENDS>\">\r\n" +
+                   "    <MSBuild Projects=\"<!$SB_PROJ>\"  BuildInParallel=\"true\"  StopOnFirstFailure=\"true\"/>\r\n" +
+                   "    </Target>\r\n" +
+                   "  </Project>\r\n";
+        }
+
+        protected override string GetExpectedResultText()
+        {
+            return "3:     <Target Name=\"<!$SB_TARGET>\" DependsOnTargets=\"<!$SB_DEPENDS>\">\r\n" +
+                   "---------------------^  The project file could not be loaded. '<', hexadecimal value 0x3C, is an invalid attribute character. Line 3, position 19.\r\n" +
+                   "C:\\Repos\\BuildAnalyzer\\UnitTests\\bin\\Debug\\msbuild.xml \r\n\r\n" +
+                   "========================\r\n" +
+                   "Total errors: 1\r\n" +
+                   "========================\r\n\r\n";
+
+        }
+    }
+}

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -20,7 +20,7 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void TestLogWithErrorsOnly2()
+        public void TestLogWithErrorsOnly()
         {
             Test(new MockLogWithErrorsOnlyFilesProvider());
         }
@@ -29,6 +29,12 @@ namespace UnitTests
         public void TestSuccessfulLog()
         {
             Test(new MockSuccessfulLogFilesProvider());
+        }
+
+        [TestMethod]
+        public void TestLogWithErrorInMsbuildXml()
+        {
+            Test(new MockLogWithErrorInMsbuildXml());
         }
 
        

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -54,6 +54,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="MockFilesProvider.cs" />
+    <Compile Include="MockLogWithErrorInMsbuildXml.cs" />
     <Compile Include="MockLogWithErrorsOnlyFilesProvider.cs" />
     <Compile Include="MockLogWithWarningsAndErrorsFilesProvider.cs" />
     <Compile Include="MockSuccessfulLogFilesProvider.cs" />


### PR DESCRIPTION
Support errors in msbuild.xml file. For example, where the project name merge tag is not translated and the build can't load the project (i.e. <!$SB_PROJ>). I've change BuildAnalyzed to cope with errors in msbuild.xml an show the details of the error including the line with the issue from msbuild.xml